### PR TITLE
DIR-7041 update unserved file types

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -36,8 +36,13 @@ http {
         add_header Content-Security-Policy "default-src *; font-src 'self' data: fonts.gstatic.com; style-src * 'unsafe-inline'; script-src * 'unsafe-inline' 'unsafe-eval'; img-src * data: 'unsafe-inline'; connect-src * 'unsafe-inline'; frame-src *; object-src 'none'; base-uri 'self'; frame-ancestors https://recovery.org/ https://*.recovery.org/;";
 
         # slow attacks by quickly returning unserved file types
-        location ~* \.(bak|zip|tar|gz|sql|php)$|/\. {
+        location ~* \.(bak|zip|tar|gz|sql|php|env|aspx)$|/\. {
              return 403;
+        }
+
+        # slow attacks by quickly returning ads.txt
+        location ~ ^/(ads\.txt)$ {
+            return 403;
         }
 
         # proxy recovery.org/wp-content/uploads/ -> s3 bucket


### PR DESCRIPTION
https://recoverybrands.atlassian.net/browse/DIR-7041

Brief Description:
DIR-7041 updated unserved file types

Example Links
https://staging.recovery.org/test.env
https://staging.recovery.org/test.aspx
https://staging.recovery.org/test.env.aspx
https://staging.recovery.org/ads.txt

Note: Only ads.txt should be blocked. We need robots.txt to load.

https://staging.recovery.org/robots.txt

Screenshot:
![image](https://github.com/American-Addiction-Centers/recovery-org-nginx/assets/86256771/3f324840-e44e-4a56-9fa3-a85001a9021e)
